### PR TITLE
Add links to walkthrough.so and simple tutorials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 ## Tutorials and sources
 
 * [editorjs.io](https://editorjs.io) — offical docs
+* [Tutorial: Integrating Editor.js into your react application](https://www.walkthrough.so/pblc/snKICMzxzedr/codelab-integrating-editor-js-into-your-react-application)
+* [Tutorial: Creating a custom editorjs block tool with React](https://www.walkthrough.so/pblc/QCawSCKwOQLn/creating-a-custom-editorjs-block-tool-with-react)
 
 ## Projects Using Editor.js
 
@@ -171,6 +173,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 
 * [⟑ djit.su](https://djit.su) — hyper-reactive notebook interface
 * [Poda](https://poda.io) — Project planning and roadmaping
+* [Walkthrough](http://walkthrough.so/) - Write great codelab style tutorials.
 
 ### Open source projects
 


### PR DESCRIPTION
I created a website - walkthrough.so to write Google Codelab style tutorials. 

It is a NextJS application with the core editor to write content is editorjs. 
I also wrote two small tutorials on how to use editorjs with react and I would like to share those here.