### PR TITLE
Removal of a non-functional link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 * [orchid-editorjs-field](https://github.com/AlexSabur/orchid-editorjs-field)
 * [yii2-editorjs-widget](https://github.com/zakurdaev/yii2-editorjs-widget) — Editor.js widget for Yii 2
 * [EditorjsBundle](https://github.com/tbmatuka/EditorjsBundle) — Symfony bundle for Editor.js
-* [editorjs2html](https://github.com/aswal94/editorjs2html) — Convert blocks of editorjs into html. The parser has been written in php
 * [nova-editor-js](https://github.com/advoor/nova-editor-js) — Editor JS field for Laravel Nova
 * [codex-to-html](https://github.com/Archakov06/codex-to-html) — Converter EditorJS JSON to HTML
 * [magento2-editorjs](https://github.com/Wamoco/magento2-editorjs) — Editor.js module for Magento 2


### PR DESCRIPTION
The editorjs2html directory does not exist any more, we fall on page 404. I propose to clean this link