### PR TITLE
Add Inline Hotkey Plugin to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 * [editorjs-text-color-plugin](https://www.npmjs.com/package/editorjs-text-color-plugin) - Inline tool for coloring/marking selected text with customized colors
 * [VolgaIgor/editorjs-annotation](https://github.com/VolgaIgor/editorjs-annotation) — Tool for adding an extended annotation to any text in EditorJS blocks
 * [editorjs-comment](https://github.com/osain-az/editorjs-comment) - Tool that allows you to add comment to editorjs
+* [editorjs-inline-hotkey](https://github.com/Stuhl/editorjs-inline-hotkey) - Inline Tool that marks text as Hotkey
 
 ### Block Tune Tools
 


### PR DESCRIPTION
I made a inline hotkey plugin where you can mark text as hotkey:
![demo](https://github.com/user-attachments/assets/0cd4fc3f-e417-4704-838c-32e2d0696448)

The plugin can easily be customized with a simple css class and also follows accessability guidelines automatically since it uses the `<kbd>` tag.