### PR TITLE
Adding Spoiler Tool with easy customization to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 * [VolgaIgor/editorjs-annotation](https://github.com/VolgaIgor/editorjs-annotation) — Tool for adding an extended annotation to any text in EditorJS blocks
 * [editorjs-comment](https://github.com/osain-az/editorjs-comment) - Tool that allows you to add comment to editorjs
 * [editorjs-inline-hotkey](https://github.com/Stuhl/editorjs-inline-hotkey) - Inline Tool that marks text as Hotkey
+* [editorjs-inline-spoiler](https://github.com/Stuhl/editorjs-inline-spoiler) - Inline Spoiler Tool that adds spoiler to text. Can be customized easily via CSS (Examples included)
 
 ### Block Tune Tools
 


### PR DESCRIPTION
I've added my new spoiler inline tool to the readme. With this tool, you can add spoiler to text. Compared to other plugins that are out there, this one can be easily customized via CSS (Examples included)

Default:
![demo](https://github.com/user-attachments/assets/1b20a42e-4a9c-4345-8f40-f04795902ec0)


With custom styles:
![demo2](https://github.com/user-attachments/assets/23ebb39b-b3d0-4a4a-8cb2-2224433da1c8)

