### PR TITLE
Add group-image tool with drag and drop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 * [editorjs-drawing-tool](https://github.com/blade47/editorjs-drawing-tool) - Drawing Tool for Editor.js
 * [@cychann/editorjs-group-image](https://github.com/cychann/editorjs-group-image) - Multi-image block with advanced drag-and-drop functionality
 
-
 #### Table
 
 * [@editorjs/table](https://github.com/editor-js/table) — table constructor tool


### PR DESCRIPTION
Provides a powerful multi-image block with advanced drag-and-drop functionality. Glad to contribute to this awesome package.

https://www.npmjs.com/package/@cychann/editorjs-group-image

![2025-06-232 03 19-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ee4afb96-9ed5-4362-8fd9-0c56ec64b23e)
